### PR TITLE
Add news to website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 # Builds website but does not deploy it
 on:
-  push:
   pull_request:
       branches:
         - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+# Builds website but does not deploy it
+on:
+  push:
+  pull_request:
+      branches:
+        - master
+        - main
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout code
+      - uses: actions/checkout@v2
+      # Use ruby/setup-ruby to shorten build times
+      # https://github.com/ruby/setup-ruby
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7 # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      # Install Node as this is needed for PostCSS
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      # Install PostCSS plugins (from your package.json)
+      - name: Install Tailwind
+        run: |
+          mkdir node_modules
+          npm install
+          npm install tailwindcss@3.0.0 @tailwindcss/typography@latest postcss@latest postcss-scss@latest autoprefixer@latest cssnano@latest
+      - name: Build site
+      # use jekyll-action-ts to build
+      # https://github.com/limjh16/jekyll-action-ts
+        uses: limjh16/jekyll-action-ts@v2
+        with:
+          enable_cache: true
+          # custom_opts: '--verbose --trace'  #'--drafts --future'
+          ### If you need to specify any Jekyll build options, enable the above input
+          ### Flags accepted can be found here https://jekyllrb.com/docs/configuration/options/#build-command-options
+      # use actions-gh-pages to deploy
+      # https://github.com/peaceiris/actions-gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-  pull_request:
-    branches:
-      - master
-      - main
 
 jobs:
   deploy:

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,4 +1,4 @@
-<div class="news publications">
+<div class="news">
             <h1 class = "text-2xl font-extralight">News</h1>
             {% if site.news != blank -%} 
             <div class="table-responsive">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@ layout: default
 <div class="post">
 
   <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
+    <h1 class="post-title text-3xl">{{ page.title }}</h1>
     <p class="post-meta">{{ page.date | date: "%B %-d, %Y" }}{%- if page.author -%} • {{ page.author }}{%- endif -%}{%- if page.meta -%} • {{ page.meta }}{%- endif -%}</p>
     <p class="post-tags">
       <a href="{{ year | prepend: '/blog/' | prepend: site.baseurl}}"> <i class="fas fa-calendar fa-sm"></i> {{ year }} </a>

--- a/_news/announcement_1.md
+++ b/_news/announcement_1.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-date: 2015-10-22 15:59:00-0400
+date: 2021-02-10 12:00:00-0000
 inline: true
 ---
 
-A simple inline announcement.
+Andrew has been awarded an ISSF grant to perform a single-cell multiomics study of eye organoids

--- a/_news/announcement_2.md
+++ b/_news/announcement_2.md
@@ -1,31 +1,35 @@
 ---
 layout: post
-title: A long announcement with details
-date: 2015-11-07 16:11:00-0400
+title: Linda and Elena have joined the group!
+date: 2021-10-01 12:00:00-0000
 inline: false
 ---
 
-Announcements and news can be much longer than just quick inline posts. In fact, they can have all the features available for the standard blog posts. See below.
+We have welcomed two new members to the group, <br><br>
 
-***
+## Linda Nguyễn
 
-Jean shorts raw denim Vice normcore, art party High Life PBR skateboard stumptown vinyl kitsch. Four loko meh 8-bit, tousled banh mi tilde forage Schlitz dreamcatcher twee 3 wolf moon. Chambray asymmetrical paleo salvia, sartorial umami four loko master cleanse drinking vinegar brunch. <a href="https://www.pinterest.com">Pinterest</a> DIY authentic Schlitz, hoodie Intelligentsia butcher trust fund brunch shabby chic Kickstarter forage flexitarian. Direct trade <a href="https://en.wikipedia.org/wiki/Cold-pressed_juice">cold-pressed</a> meggings stumptown plaid, pop-up taxidermy. Hoodie XOXO fingerstache scenester Echo Park. Plaid ugh Wes Anderson, freegan pug selvage fanny pack leggings pickled food truck DIY irony Banksy.
+<br>
 
-#### Hipster list
-<ul>
-    <li>brunch</li>
-    <li>fixie</li>
-    <li>raybans</li>
-    <li>messenger bag</li>
-</ul>
+<img src = "/assets/img/group-members/linda-480.webp" width = "200">
 
-Hoodie Thundercats retro, tote bag 8-bit Godard craft beer gastropub. Truffaut Tumblr taxidermy, raw denim Kickstarter sartorial dreamcatcher. Quinoa chambray slow-carb salvia readymade, bicycle rights 90's yr typewriter selfies letterpress cardigan vegan.
+<br>
+Linda is a [Precision Medicine DTP](https://www.ed.ac.uk/usher/precision-medicine)
+PHD student studying the mechanisms of why photoreceptors die in retinitis
+pigmentosa and will be leveraging our group's experience with single cell
+transcriptomics. In addition to being supervised by Dr Catalina Vallejos, Linda
+is also supervised by [Dr Pleasantine Mill and Dr Roly
+Megaw](https://www.ed.ac.uk/mrc-human-genetics-unit/research/mill-group). 
+<br><br>
+ 
+## Elena Bernabeu
+ 
+<br>
 
-***
+<img src = "/assets/img/group-members/elena-480.webp" width = "200">
 
-Pug heirloom High Life vinyl swag, single-origin coffee four dollar toast taxidermy reprehenderit fap distillery master cleanse locavore. Est anim sapiente leggings Brooklyn ea. Thundercats locavore excepteur veniam eiusmod. Raw denim Truffaut Schlitz, migas sapiente Portland VHS twee Bushwick Marfa typewriter retro id keytar.
-
-> We do not grow absolutely, chronologically. We grow sometimes in one dimension, and not in another, unevenly. We grow partially. We are relative. We are mature in one realm, childish in another.
-> —Anais Nin
-
-Fap aliqua qui, scenester pug Echo Park polaroid irony shabby chic ex cardigan church-key Odd Future accusamus. Blog stumptown sartorial squid, gastropub duis aesthetic Truffaut vero. Pinterest tilde twee, odio mumblecore jean shorts lumbersexual.
+<br>
+Elena is a postdoctoral research fellow and will be researching [genomic,
+epigenomic, and proteomic predictors of Alzheimer's disease](https://www.ed.ac.uk/centre-genomic-medicine/news-events/latest-news/genetics-epigenetics-and-proteomics-for-ad) using data
+from [Generation Scotland](https://www.ed.ac.uk/generation-scotland). Elena is
+supervised by [Dr Riccardo Marioni](https://marioni-group.owlstown.net) and Dr Catalina Vallejos. 

--- a/_news/announcement_3.md
+++ b/_news/announcement_3.md
@@ -1,7 +1,0 @@
----
-layout: post
-date: 2016-01-15 07:59:00-0400
-inline: true
----
-
-A simple inline announcement with Markdown emoji! :sparkles: :smile:

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -5,7 +5,7 @@ permalink: /
 subtitle: Understanding heterogeneity in complex biomedical data
 group_pic: assets/img/group-members/prof_pic.jpg
 
-news: false  # includes a list of news items
+news: true  # includes a list of news items
 selected_papers: true # includes a list of papers marked as "selected={true}"
 social: true  # includes social icons at the bottom of the page
 importance: 1

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -75,6 +75,7 @@ blockquote {
   }
 }
 
+
 // Citation
 .citation, .citation-number {
   color: var(--global-theme-color);
@@ -318,34 +319,6 @@ footer.sticky-bottom {
   }
 }
 
-.post-list {
-  margin: 0;
-  margin-bottom: 40px;
-  padding: 0;
-  li {
-    border-bottom: 1px solid var(--global-divider-color);
-    list-style: none;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
-    .post-meta {
-      color: var(--global-text-color-light);
-      font-size: 0.875rem;
-      margin-bottom: 0;
-    }
-    .post-tags {
-      color: var(--global-text-color-light);
-      font-size: 0.875rem;
-      padding-top: 0.25rem;
-    }
-    a {
-      color: var(--global-text-color);
-      text-decoration: none;
-      &:hover {
-        color: var(--global-theme-color);
-      }
-    }
-  }
-}
 
 .pagination {
   .page-item {
@@ -598,6 +571,30 @@ html.transition *:after {
         blockquote {
           border-left: 5px solid var(--global-theme-color);
           padding: 8px;
+      }
+      h1 {
+        font-size: 1.875rem/* 30px */;
+        line-height: 2.25rem/* 36px */;
+      }
+
+      h2 {
+        font-size: 1.5rem/* 24px */;
+        line-height: 2rem/* 32px */;
+      }
+
+      h3 {
+        font-size: 1.25rem/* 20px */;
+        line-height: 1.75rem/* 28px */;
+      }
+      img {
+          border-radius: 0.75rem/* 12px */;
+          display: block;
+          margin-left: auto;
+          margin-right: auto;
+        }
+      li {
+        list-style-type: disc;
+        
       }
 }
 }


### PR DESCRIPTION
# Add news to website

This PR provides support for a news section on the homepage.

I have included two news posts (one inline and one in-depth): Andrew's ISSF grant and Linda & Elena joining the group. @catavallejos if you could check the information for the latter (in _news/announcement_2.md) is correct before I merge into the website, that would be great! (I would tag Linda and Elena but neither seem to be in the VallejosGroup GitHub organisation).

Closes #6 